### PR TITLE
Update req.rs

### DIFF
--- a/github-hosts/src/req.rs
+++ b/github-hosts/src/req.rs
@@ -3,10 +3,11 @@ use std::time::Duration;
 
 const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
 
-pub const GITHUB_520: [&str; 3] = [
+pub const GITHUB_HOSTS: [&str; 4] = [
     "https://api.hellogithub.com/GitHub520/hosts",
     "https://raw.hellogithub.com/hosts",
     "https://raw.githubusercontent.com/521xueweihan/GitHub520/main/hosts",
+    "https://www.suni.cf:8880/Hosts/GithubHosts.txt",
 ];
 
 pub fn fetch() -> Option<String> {
@@ -16,7 +17,7 @@ pub fn fetch() -> Option<String> {
         .build()
         .unwrap();
 
-    for url in GITHUB_520 {
+    for url in GITHUB_HOSTS {
         if let Ok(resp) = client.get(url).send() {
             if let Ok(body) = resp.text() {
                 println!("valid url: {}", url);


### PR DESCRIPTION
增加了一个hosts同步url。
原本的三个url经常无法访问。
hosts解析同步仓库地址： https://github.com/JohyC/Hosts
